### PR TITLE
Add README files to NuGet packages and reorganize documentation

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -14,6 +14,7 @@
     <PackageProjectUrl>https://github.com/your-org/csharp-tree-sitter</PackageProjectUrl>
     <RepositoryUrl>https://github.com/your-org/csharp-tree-sitter</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>基于Tree-sitter的TypeScript解析器 - 支持跨平台Native库自动管理</PackageReleaseNotes>
     
     <!-- 构建配置 -->

--- a/README.md
+++ b/README.md
@@ -2,42 +2,7 @@
 
 基于Tree-sitter的TypeScript解析器 - .NET绑定
 
-## 构建步骤
-
-```bash
-# 1. 复制运行时文件
-(cd tree-sitter/ && make clean && make)
-
-RID=$(dotnet --info | grep "RID:" | awk '{print $2}')
-mkdir -p TypeScriptParser.Native/runtimes/$RID/native
-cp -r tree-sitter/dist/* TypeScriptParser.Native/runtimes/$RID/native/
-
-# 2. 恢复依赖
-dotnet restore
-
-# 3. 构建项目
-dotnet build -c Release
-
-# 4. 运行测试
-dotnet test --configuration Release --no-build
-
-# 5. 打包NuGet包
-dotnet pack -c Release --no-build -o ./artifacts
-```
-
-## 自动化构建
-
-### 开发流程
-1. 创建功能分支
-2. 提交Pull Request → 自动构建测试
-3. 合并到main分支
-
-### 发布流程
-1. 创建版本标签：`git tag v1.2.0 && git push origin v1.2.0`
-2. 自动构建测试发布到NuGet.org
-3. 版本号格式：`1.2.0.{构建号}`
-
-## 手动构建
+## 快速开始
 
 ```bash
 # 1. 构建native库
@@ -48,29 +13,42 @@ RID=$(dotnet --info | grep "RID:" | awk '{print $2}')
 mkdir -p TypeScriptParser.Native/runtimes/$RID/native
 cp -r tree-sitter/dist/* TypeScriptParser.Native/runtimes/$RID/native/
 
-# 3. .NET构建
+# 3. 构建和测试
 dotnet restore
 dotnet build -c Release
-dotnet test --configuration Release --no-build
-dotnet pack -c Release --no-build -o ./artifacts
-```
+dotnet test --configuration Release 
 
-## 开发构建
-
-```bash
-# Debug模式构建和测试
-dotnet build -c Debug
-dotnet test --configuration Debug --no-build
+# 4. 打包NuGet包
+dotnet pack -c Release  -o ./artifacts
 ```
 
 ## 项目结构
 
-- `TypeScriptParser/` - 主要的.NET绑定库
-- `TypeScriptParser.Native/` - 跨平台Native库包
-- `TypeScriptParser.Tests/` - 单元测试
+- [`TypeScriptParser/`](TypeScriptParser/) - 主要的.NET绑定库
+- [`TypeScriptParser.Native/`](TypeScriptParser.Native/) - 跨平台Native库包
+- [`TypeScriptParser.Tests/`](TypeScriptParser.Tests/) - 单元测试
 
-## 支持平台
+## 开发指南
 
+### Debug模式构建
+```bash
+dotnet build -c Debug
+dotnet test --configuration Debug 
+```
+
+### 支持平台
 - Linux x64
 - macOS ARM64  
 - Windows x64
+
+## CI/CD流程
+
+### 开发流程
+1. 创建功能分支
+2. 提交Pull Request → 自动构建测试
+3. 合并到main分支
+
+### 发布流程
+1. 创建版本标签：`git tag v1.2.0 && git push origin v1.2.0`
+2. 自动构建测试发布到NuGet.org
+3. 版本号格式：`1.2.0.{构建号}`

--- a/TypeScriptParser.Native/TypeScriptParser.Native.csproj
+++ b/TypeScriptParser.Native/TypeScriptParser.Native.csproj
@@ -10,6 +10,11 @@
     <NoWarn>$(NoWarn);NU5128</NoWarn>
   </PropertyGroup>
 
+  <!-- README文件包含到包中 -->
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
   <!-- 包含runtime和build文件到NuGet包 -->
   <ItemGroup>
     <Content Include="runtimes/**/*" Pack="true" PackagePath="runtimes/" />

--- a/TypeScriptParser/README.md
+++ b/TypeScriptParser/README.md
@@ -1,0 +1,155 @@
+# TypeScriptParser
+
+基于Tree-sitter的TypeScript解析器.NET绑定库，提供高性能的TypeScript代码解析功能。
+
+## 安装
+
+```bash
+dotnet add package TypeScriptParser
+```
+
+## 快速开始
+
+```csharp
+using System;
+using TreeSitter.TypeScript;
+using GitHub.TreeSitter;
+
+// 创建解析器实例
+using var parser = new TypeScriptParser();
+
+// 解析TypeScript代码
+string code = @"
+function greet(name: string): string {
+    return `Hello, ${name}!`;
+}
+";
+
+using var tree = parser.ParseString(code);
+var rootNode = tree.root_node();
+
+// 遍历语法树
+Console.WriteLine($"语法树类型: {rootNode.type()}");
+Console.WriteLine($"子节点数量: {rootNode.child_count()}");
+
+// 获取源码文本
+Console.WriteLine($"源码内容: {rootNode.text(code)}");
+```
+
+## 主要功能
+
+- ✅ 完整的TypeScript语法支持
+- ✅ 高性能的增量解析
+- ✅ 跨平台支持 (Windows, Linux, macOS)
+- ✅ 详细的语法错误信息
+- ✅ 语法树遍历和查询
+
+## API 参考
+
+### TypeScriptParser 类
+
+位于 `TreeSitter.TypeScript` 命名空间。
+
+#### 构造函数
+```csharp
+var parser = new TypeScriptParser();
+```
+
+#### 主要方法
+
+**ParseString(string sourceCode)**
+- 解析TypeScript源代码字符串
+- 返回: `TSTree` - 解析后的语法树
+
+```csharp
+var tree = parser.ParseString("const x = 42;");
+```
+
+**CreateCursor(TSTree tree)**
+- 创建语法树游标用于高效遍历
+- 返回: `TSCursor` - 语法树游标对象
+
+```csharp
+using var cursor = parser.CreateCursor(tree);
+```
+
+#### 属性
+
+**Language**
+- 获取TypeScript语言对象
+- 类型: `TSLanguage`
+
+**IsAvailable**
+- 检查解析器是否可用
+- 类型: `bool`
+
+### TSTree 类 (来自 GitHub.TreeSitter)
+
+**主要方法:**
+- `root_node()` - 获取根节点
+- `copy()` - 复制语法树
+- `edit(TSInputEdit edit)` - 编辑语法树
+
+### TSNode 结构 (来自 GitHub.TreeSitter)
+
+**主要方法:**
+- `type()` - 获取节点类型名称
+- `child_count()` - 获取子节点数量
+- `child(uint index)` - 获取指定索引的子节点
+- `start_point()` / `end_point()` - 获取节点位置
+- `text(string sourceCode)` - 获取节点对应的源码文本
+
+## 语法树遍历示例
+
+```csharp
+using var parser = new TypeScriptParser();
+var tree = parser.ParseString(@"
+class Calculator {
+    add(a: number, b: number): number {
+        return a + b;
+    }
+}
+");
+
+var root = tree.root_node();
+
+// 递归遍历所有节点
+void TraverseNode(TSNode node, string source, int depth = 0)
+{
+    var indent = new string(' ', depth * 2);
+    Console.WriteLine($"{indent}{node.type()}: {node.text(source)}");
+    
+    for (uint i = 0; i < node.child_count(); i++)
+    {
+        TraverseNode(node.child(i), source, depth + 1);
+    }
+}
+
+TraverseNode(root, code);
+```
+
+## 错误处理
+
+```csharp
+using var parser = new TypeScriptParser();
+var tree = parser.ParseString("const x = ;"); // 语法错误
+
+var root = tree.root_node();
+if (root.has_error())
+{
+    Console.WriteLine("语法树包含错误");
+}
+```
+
+## 系统要求
+
+- .NET 9.0 或更高版本
+- 支持的平台：Windows (x64), Linux (x64), macOS (ARM64/x64)
+
+## 相关包
+
+- `TypeScriptParser.Native` - 包含跨平台原生库的运行时包
+
+## 许可证
+
+本项目基于MIT许可证开源。

--- a/TypeScriptParser/TypeScriptParser.csproj
+++ b/TypeScriptParser/TypeScriptParser.csproj
@@ -11,6 +11,11 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
+  <!-- README文件包含到包中 -->
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
   <!-- Native库依赖 -->
   <ItemGroup>
     <ProjectReference Include="..\TypeScriptParser.Native\TypeScriptParser.Native.csproj" />


### PR DESCRIPTION
- Add PackageReadmeFile property to Directory.Build.props
- Include README.md files in both TypeScriptParser and TypeScriptParser.Native packages
- Restructure main README with improved quick start guide and clearer project organization
- Move detailed build instructions under development section