### PR TITLE
ci: exclude dev tags from publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
   publish:
     needs: package-test
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-dev')
     
     steps:
     - name: Download NuGet Packages


### PR DESCRIPTION
Prevent publishing of development versions by adding condition to skip tags containing '-dev'